### PR TITLE
Use std::exception's what()

### DIFF
--- a/include/exceptions.h
+++ b/include/exceptions.h
@@ -45,14 +45,14 @@ public:
   /**
   @param msg error message
   */
-  Miscue( const std::string msg ) : _msg(msg) {}
+  Miscue( const std::string msg ) : _msg{"NFIR Exception: " + msg} {}
 
   /**
   @return text of the error message
   */
-  std::string message(void)
+  const char* what() const noexcept override
   {
-    return "NFIR Exception: " + _msg;
+    return _msg.c_str();
   }
 };
 

--- a/include/exceptions.h
+++ b/include/exceptions.h
@@ -45,7 +45,7 @@ public:
   /**
   @param msg error message
   */
-  Miscue( const std::string msg ) : _msg{"NFIR Exception: " + msg} {}
+  Miscue( const std::string &msg ) : _msg{"NFIR Exception: " + msg} {}
 
   /**
   @return text of the error message

--- a/src/bin/nfir.cpp
+++ b/src/bin/nfir.cpp
@@ -251,8 +251,8 @@ int main(int argc, char** argv)
         cv::imwrite( tgtPath, tgtImage );
         tmp_count += 1;
       }
-      catch( NFIR::Miscue &e ) {
-        std::cout << e.message() << std::endl;
+      catch( const NFIR::Miscue &e ) {
+        std::cout << e.what() << std::endl;
         return -1;
       }
       catch( const cv::Exception& ex ) {


### PR DESCRIPTION
Since `std::exception` is the parent class, use the expected method to retrieve the exception message.